### PR TITLE
In Case Of Zombie, Break Glass

### DIFF
--- a/ZombieWatch.js
+++ b/ZombieWatch.js
@@ -1,0 +1,32 @@
+const channel = 'REPLACE_WITH_CHANNEL_ID';
+
+const color = Math.floor(Math.random() * 0xFFFFFF);
+
+module.exports = class ZombieWatch {
+    constructor(bot) {
+        this.bot = bot;
+        this.send({
+            title: `Greetings!`,
+            description: `My name is 0x${this.color}, and I will be your Zombie Watcher for this evening.`
+        });
+
+        this.interval = setInterval(this.report.bind(this), 1000 * 60 * 10); // every 10 minutes, adjust as needed
+    }
+
+    get color() {
+        return color.toString(16).toUpperCase();
+    }
+
+    async send(embed) {
+        embed.color = color;
+        await this.bot.createMessage(channel, {
+            embed
+        });
+    }
+
+    async report() {
+        await this.send({
+            description: `Hello! This is 0x${this.color} checking in.`
+        });
+    }
+}

--- a/server.js
+++ b/server.js
@@ -31,6 +31,13 @@ var bot = new Eris.CommandClient(
 );
 const num = Math.random();
 
+/* BEGIN ZOMBIEWATCH */
+
+const ZombieWatch = require('./ZombieWatch');
+const zombieWatch = new ZombieWatch(bot);
+
+/* END ZOMBIEWATCH */
+
 bot.on("guildCreate", async guild => {
     for (const [id, channel] of guild.channels) {
       if (channel.type === 0) { // check if text channel


### PR DESCRIPTION
This PR adds zombie process monitoring in the following form:
1. Assign the process a random ID (for visual purposes, I use a 6-digit hexadecimal integer, AKA a hex color code)
2. Announce in a specified channel that the process has gone live
3. Every 10 minutes (adjust as needed), output a message in the logging channel

What does this accomplish? It allows you to see
1. When a new process starts
2. Approximately when the process dies

For implementation, change the `channel` variable in `ZombieWatch.js` to the channel to put logging into.

Good luck!